### PR TITLE
refactor script in own file

### DIFF
--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -129,22 +129,3 @@ if (!customElements.get("product-info")) {
     }
   );
 }
-
-// Get a reference to the "Size detail" element
-const sizeDetailElement = document.getElementById("size-detail");
-
-// Get a reference to all the radio buttons for size selection
-const sizeRadioButtons = document.querySelectorAll('input[name="サイズ"]');
-
-// Add event listeners to each radio button
-sizeRadioButtons.forEach((radioButton) => {
-  radioButton.addEventListener("change", () => {
-    // Get the selected size from the value attribute of the checked radio button
-    const selectedSize = document.querySelector(
-      'input[name="サイズ"]:checked'
-    ).value;
-
-    // Update the content of the "Size detail" element
-    sizeDetailElement.textContent = `Size detail: ${selectedSize}`;
-  });
-});

--- a/assets/variant-selector.js
+++ b/assets/variant-selector.js
@@ -1,0 +1,23 @@
+// This script will update the metafield data displayed on the product page depending on the size selected.
+
+const sizeDetailElement = document.getElementById("size-detail");
+
+const sizeRadioButtons = document.querySelectorAll('input[name="サイズ"]');
+
+sizeRadioButtons.forEach((radioButton) => {
+  radioButton.addEventListener("change", () => {
+    const selectedSize = document.querySelector(
+      'input[name="サイズ"]:checked'
+    ).value;
+
+    const selectedVariants = productData.variants.filter(
+      (variant) => variant.サイズ === selectedSize
+    );
+    const compositionDetails = selectedVariants
+      .map((variant) => variant.size_detail)
+      .join(", ");
+    sizeDetailElement.textContent = `Size detail: ${compositionDetails}`;
+  });
+});
+
+// サイズ;

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -75,7 +75,25 @@
           -%}
           {%- if product.selected_or_first_available_variant.available == false or quantity_rule_soldout -%}
             {%- else -%}
-            <p id="size-detail">Size detail: {{ product.selected_or_first_available_variant.metafields.custom.size }}</p>
+            <!-- here we load all the metafield info from the begining so the script takes from here -->
+            <script>
+              var productData = {
+                variants: [
+                  {% for variant in product.variants %}
+                  {
+                    id: {{ variant.id }},
+                    サイズ: "{{ variant.option1 }}",
+                    size_detail: "{{ variant.metafields.custom.size_detail }}"
+                  },
+                  {% endfor %}
+                ]
+              };
+            </script>
+
+            <!--Here the first metafield value will be placed and after it will be updated depending on the variant selection -->
+            <p id="size-detail">
+              Size detail: {{ product.selected_or_first_available_variant.metafields.custom.size_detail }}
+            </p>
 
             <button
               id="ProductSubmitButton-{{ section_id }}"
@@ -154,5 +172,6 @@
     </pickup-availability>
 
     <script src="{{ 'pickup-availability.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'variant-selector.js' | asset_url }}" defer="defer"></script>
   {%- endif -%}
 </div>


### PR DESCRIPTION
- The script loads the Size and metadata of each product at the beginning to match it later when select another variant
- Refactored variant-selector on its own file and not in product-info